### PR TITLE
Update evaluate_f0.py; changed MCD description to LogF0

### DIFF
--- a/egs2/TEMPLATE/asr1/pyscripts/utils/evaluate_f0.py
+++ b/egs2/TEMPLATE/asr1/pyscripts/utils/evaluate_f0.py
@@ -173,7 +173,7 @@ def calculate(
 
 def get_parser() -> argparse.Namespace:
     """Get argument parser."""
-    parser = argparse.ArgumentParser(description="Evaluate Mel-cepstrum distortion.")
+    parser = argparse.ArgumentParser(description="Evaluate log-F0 RMSE.")
     parser.add_argument(
         "gen_wavdir_or_wavscp",
         type=str,


### PR DESCRIPTION
Line 176 in get_parser() in evaluate_f0.py decribes MCD calulation, but this script is for log-F0 RMSE. Argparse description is changed accordingly.

## What?

Changed argument parser description from "Evaluate Mel-cepstrum distortion." to "Evaluate log-F0 RMSE."

## Why?

evaluate_f0.py calculates log-F0 RMSE

## See also

<!-- Write additional information if necessary (e.g., referecne, related PRs or Issues). -->
